### PR TITLE
adding test data for #67

### DIFF
--- a/test/go_libxml2_local.xml
+++ b/test/go_libxml2_local.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<libxml2 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://xmlsoft.org/"
+         xsi:schemaLocation="http://xmlsoft.org/ ./schema/projects/go_libxml2_local.xsd">
+
+  <sub attrReq="foo" attrOpt="bar">
+    <nestedInclude hashType="sha1">4cfcf843c66979eb1df2bd0c52817edb753a52ba</nestedInclude>
+  </sub>
+  <sub attrReq="foo2">
+    <sub2>this is a test string only.</sub2>
+    <nestedInclude hashType="sha512">be218408a748759fb98363593b8f544eb054171bced856ca98bd972823dec0b07b205453fc3c46f23c934d0959f1e05b609c011b6ada84a7050ad7c910b24bf1</nestedInclude>
+  </sub>
+  <sub attrReq="foo3" attrBoolNoDef="false">
+    <sub2>foobar</sub2>
+    <nestedInclude hashType="md5">f7b34871a562283ee92bbda00485eb45</nestedInclude>
+  </sub>
+
+</libxml2>

--- a/test/go_libxml2_remote.xml
+++ b/test/go_libxml2_remote.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<libxml2 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://xmlsoft.org/"
+         xsi:schemaLocation="http://xmlsoft.org/ http://schema.xml.r00t2.io/projects/go_libxml2.xsd">
+
+  <sub attrReq="foo" attrOpt="bar">
+    <nestedInclude hashType="sha1">4cfcf843c66979eb1df2bd0c52817edb753a52ba</nestedInclude>
+  </sub>
+  <sub attrReq="foo2">
+    <sub2>this is a test string only.</sub2>
+    <nestedInclude hashType="sha512">be218408a748759fb98363593b8f544eb054171bced856ca98bd972823dec0b07b205453fc3c46f23c934d0959f1e05b609c011b6ada84a7050ad7c910b24bf1</nestedInclude>
+  </sub>
+  <sub attrReq="foo3" attrBoolNoDef="false">
+    <sub2>foobar</sub2>
+    <nestedInclude hashType="md5">f7b34871a562283ee92bbda00485eb45</nestedInclude>
+  </sub>
+
+</libxml2>

--- a/test/schema/lib/types/cksum.xsd
+++ b/test/schema/lib/types/cksum.xsd
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+    <xs:include schemaLocation="./std.xsd"/>
+    <xs:include schemaLocation="./net.xsd"/>
+    <xs:include schemaLocation="./unix.xsd"/>
+
+    <xs:simpleType name="t_cksum_algo">
+        <!-- Geared towards python. -->
+        <!-- tuple(sorted(list(hashlib.algorithms_available.union(set(('adler32', 'crc32')))))) -->
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="adler32"/>
+            <xs:enumeration value="blake2b"/>
+            <xs:enumeration value="blake2s"/>
+            <xs:enumeration value="crc32"/>
+            <xs:enumeration value="md4"/>
+            <xs:enumeration value="md5"/>
+            <xs:enumeration value="md5-sha1"/>
+            <xs:enumeration value="mdc2"/>
+            <xs:enumeration value="ripemd160"/>
+            <xs:enumeration value="sha1"/>
+            <xs:enumeration value="sha224"/>
+            <xs:enumeration value="sha256"/>
+            <xs:enumeration value="sha384"/>
+            <xs:enumeration value="sha3_224"/>
+            <xs:enumeration value="sha3_256"/>
+            <xs:enumeration value="sha3_384"/>
+            <xs:enumeration value="sha3_512"/>
+            <xs:enumeration value="sha512"/>
+            <xs:enumeration value="sha512_224"/>
+            <xs:enumeration value="sha512_256"/>
+            <xs:enumeration value="shake_128"/>
+            <xs:enumeration value="shake_256"/>
+            <xs:enumeration value="sm3"/>
+            <xs:enumeration value="whirlpool"/>
+            <xs:whiteSpace value="collapse"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="t_cksum_file">
+        <xs:simpleContent>
+            <xs:extension base="t_net_generic_resource">
+                <xs:attribute name="hashType" use="required" type="t_cksum_algo"/>
+                <xs:attribute name="fileType" use="required" type="t_cksum_file_filetype"/>
+                <xs:attribute name="filePath" use="optional" type="t_unix_filepath"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:simpleType name="t_cksum_file_filetype">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="gnu"/>
+            <xs:enumeration value="bsd"/>
+            <xs:whiteSpace value="collapse"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="t_cksum_hash">
+        <xs:simpleContent>
+            <xs:extension base="t_std_nonempty">
+                <xs:attribute name="hashType" use="required" type="t_cksum_algo"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="t_cksum_verify">
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="checksum" minOccurs="0" maxOccurs="unbounded" type="t_cksum_hash">
+            </xs:element>
+            <xs:element name="checksumFile" minOccurs="0" maxOccurs="unbounded" type="t_cksum_file"/>
+        </xs:choice>
+    </xs:complexType>
+
+</xs:schema>

--- a/test/schema/lib/types/net.xsd
+++ b/test/schema/lib/types/net.xsd
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+    <xs:include schemaLocation="./std.xsd"/>
+
+    <xs:simpleType name="t_net_addr_ip4">
+        <xs:restriction base="xs:string">
+            <!-- This is a REALLY LAZY regex. Matching IPv4 in regex is ugly as heck, so we do that in-code.
+                 This is just a gatekeeper. -->
+            <xs:pattern value="\s*[0-9.]{7,15}\s*"/>
+            <xs:whiteSpace value="collapse"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="t_net_addr_ip6">
+        <xs:restriction base="xs:string">
+            <!-- This is a REALLY LAZY regex. Matching IPv6 in regex is ugly as heck, so we do that in-code.
+                 This is just a gatekeeper. -->
+            <xs:pattern value="\s*[A-Za-z0-9:]+\s*"/>
+            <xs:whiteSpace value="collapse"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="t_net_authselect">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="basic"/>
+            <xs:enumeration value="digest"/>
+            <xs:enumeration value="none"/>
+            <xs:whiteSpace value="collapse"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="t_net_auto_ip6">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="slaac"/>
+            <xs:enumeration value="dhcp6"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="t_net_both_addr">
+        <xs:union memberTypes="t_net_addr_ip4 t_net_addr_ip6"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="t_net_both_qualified_addr">
+        <xs:union memberTypes="t_net_qualified_addr_ip4 t_net_qualified_addr_ip6"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="t_net_email_addr">
+        <xs:restriction base="xs:string">
+            <!-- Thanks, my dude: https://stackoverflow.com/a/2147859/733214 -->
+            <!-- And turns out email local parts are WAY more permissive than I thought:
+                 https://stackoverflow.com/a/2049510/733214 -->
+            <xs:pattern value="[^@]+@[^\.]+\..+"/>
+            <xs:whiteSpace value="collapse"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="t_net_ftp_resource">
+        <xs:simpleContent>
+            <xs:extension base="t_std_uri">
+                <xs:attribute name="user" type="t_std_nonempty" use="optional" default="anonymous"/>
+                <xs:attribute name="password" type="t_std_nonempty" use="optional"/>
+                <!-- This should be handled in-application by looking at the scheme in the URI itself. -->
+                <!-- <xs:attribute name="startTLS" type="xs:boolean" use="optional" default="false"/> -->
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="t_net_generic_resource">
+        <xs:simpleContent>
+            <xs:extension base="t_std_uri">
+                <xs:attribute name="user" type="t_std_nonempty" use="optional"/>
+                <xs:attribute name="password" type="t_std_nonempty" use="optional"/><!-- If FTP & none, "anonymous" -->
+                <!-- This should be handled in-application by looking at the scheme in the URI itself. -->
+                <!-- <xs:attribute name="startTLS" type="xs:boolean" use="optional" default="false"/> --><!-- FTP -->
+                <xs:attribute name="authType" type="t_net_authselect" use="optional" default="none"/><!-- HTTP(S) -->
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="t_net_http_resource">
+        <xs:simpleContent>
+            <xs:extension base="t_std_uri">
+                <xs:attribute name="user" type="t_std_nonempty" use="optional"/>
+                <xs:attribute name="password" type="t_std_nonempty" use="optional"/>
+                <xs:attribute name="authtype" type="t_net_authselect" use="optional" default="none"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:simpleType name="t_net_http_basic_uri">
+        <xs:restriction base="xs:anyURI">
+            <xs:pattern value="https?://.+/?"/>
+            <xs:whiteSpace value="collapse"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="t_net_mac_addr">
+        <xs:restriction base="xs:token">
+            <!-- EUI48[RFC7043§3] (previously MAC48[RFC7042§2.1]) -->
+            <xs:pattern value="\s*([A-Fa-f0-9]{2}[:-]?){5}[A-Fa-f0-9]{2}\s*"/>
+            <!-- EUI64[RFC7043§4, RFC4291§2.5.1] -->
+            <xs:pattern value="\s*([A-Fa-f0-9]{2}[:-]?){3}[Ff]{3}[FfEe][:-]?([A-Fa-f0-9]{2}[:-]?){2}[A-Fa-f0-9]{2}\s*"/>
+            <xs:pattern
+                    value="\s*([A-Fa-f0-9]{2}[:-]?){3}[A-Fa-f0-9]{4}[:-]?([A-Fa-f0-9]{2}[:-]?){2}[A-Fa-f0-9]{2}\s*"/>
+            <xs:whiteSpace value="collapse"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="t_net_netproto">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="ipv4"/>
+            <xs:enumeration value="ipv6"/>
+            <xs:whiteSpace value="collapse"/>
+        </xs:restriction>
+    </xs:simpleType>
+    
+    <xs:simpleType name="t_net_port">
+        <xs:restriction base="xs:positiveInteger">
+            <xs:minInclusive value="1"/>
+            <xs:maxInclusive value="65535"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="t_net_proto">
+        <!-- TODO: expand? Remove gre? -->
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="tcp"/>
+            <xs:enumeration value="udp"/>
+            <xs:enumeration value="icmp"/>
+            <xs:enumeration value="gre"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="t_net_qualified_addr_ip4">
+        <!-- This is a REALLY LAZY regex. Matching IPv4 in regex is ugly as heck, so we do that in-code.
+             This is just a gatekeeper. -->
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\s*[0-9.]{7,15}/[0-9]{1,2}\s*"/>
+            <xs:whiteSpace value="collapse"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="t_net_qualified_addr_ip6">
+        <!-- This is a REALLY LAZY regex. Matching IPv6 in regex is ugly as heck, so we do that in-code.
+             This is just a gatekeeper. -->
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\s*[A-Za-z0-9:]+/[0-9]{1,3}\s*"/>
+            <xs:whiteSpace value="collapse"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- TODO: "enterprise" WPA2 (add'l details)?
+           WPA3?
+           EAP,
+           eduroam (https://github.com/rst0git/netctl-eduroam-config/blob/master/eduroam), etc. -->
+    <!-- wep64, wep128, wpa-psk:tkip, wpa-psk:aes, wpa2-psk:tkip, wpa2-psk:aes, wpa2-psk:tkip/aes -->
+    <xs:complexType name="t_net_wifi_crypto">
+        <xs:all>
+            <xs:element name="type" minOccurs="1" maxOccurs="1" default="wpa2">
+                <xs:simpleType>
+                    <xs:restriction base="xs:token">
+                        <!-- <xs:enumeration value="wep"/> -->
+                        <xs:enumeration value="wpa"/>
+                        <xs:enumeration value="wpa2"/>
+                        <!-- <xs:enumeration value="wpa3"/> -->
+                        <xs:whiteSpace value="collapse"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <!-- Only valid for WPA/WPA2 (and maybe WPA3 once supported?) -->
+            <xs:element name="creds" minOccurs="1" maxOccurs="1">
+                <xs:complexType>
+                    <xs:choice minOccurs="1" maxOccurs="1">
+                        <!-- "personal" -->
+                        <xs:element name="psk">
+                            <xs:complexType>
+                                <xs:simpleContent>
+                                    <xs:extension base="xs:string">
+                                        <!-- A key can be generated via "wpa_passphrase <ssid> <passphrase>" -->
+                                        <!-- or via genPSK.py in extras/ -->
+                                        <xs:attribute name="isKey" type="xs:boolean" use="optional" default="false"/>
+                                    </xs:extension>
+                                </xs:simpleContent>
+                            </xs:complexType>
+                        </xs:element>
+                        <!-- TODO -->
+                        <!-- <xs:element name="enterprise"></xs:element> -->
+                    </xs:choice>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+
+</xs:schema>

--- a/test/schema/lib/types/std.xsd
+++ b/test/schema/lib/types/std.xsd
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+    <xs:simpleType name="t_std_UUID4">
+        <xs:restriction base="xs:token">
+            <xs:pattern value="\s*[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\s*"/>
+            <xs:whiteSpace value="collapse"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="t_std_base64">
+        <xs:restriction base="xs:token">
+            <xs:pattern value="[A-Za-z0-9+/=]+"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="t_std_cmdopts">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="name" use="required" type="xs:token"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:simpleType name="t_std_envvar">
+        <xs:restriction base="xs:token">
+            <xs:pattern value="env:[A-Za-z_]+[A-Za-z0-9_]*"/>
+            <xs:whiteSpace value="collapse"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="t_std_epoch_or_iso">
+        <!-- positiveInteger is used for UNIX Epoch. -->
+        <xs:union memberTypes="xs:dateTime xs:positiveInteger"/>
+    </xs:simpleType>
+    
+    <xs:simpleType name="t_std_list_comma">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[^,]+(,[^,])*"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="t_std_list_space">
+        <xs:list itemType="xs:token"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="t_std_nonempty">
+        <xs:restriction base="xs:token">
+            <xs:minLength value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="t_std_uri">
+        <xs:restriction base="xs:anyURI">
+            <xs:pattern value="\s*(https?|ftps?|file)://.+\s*"/>
+            <xs:whiteSpace value="collapse"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+</xs:schema>

--- a/test/schema/lib/types/unix.xsd
+++ b/test/schema/lib/types/unix.xsd
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+  <xs:include schemaLocation="./std.xsd"/>
+
+  <xs:complexType name="t_unix_arg">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="value" type="xs:string" use="optional"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="t_unix_args">
+    <xs:choice minOccurs="1" maxOccurs="unbounded">
+      <xs:element name="long" type="t_unix_arg"/>
+      <xs:element name="short" type="t_unix_arg"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <!-- These were a pain to figure out. -->
+  <!-- wtf. doesn't seem to work?
+        dir: ^\s*(~?/[^/]*)+/?\s*$
+        file: ^\s*(~?/[^/]+)+\s*$
+        reldir: ^\s*[^/](([^/]*)+/?)+\s*$
+        relfile: ^\s*[^/]+(/|[^/]*)*[^/]+\s*$
+  -->
+  <!-- ABSOLUTE directory path -->
+  <xs:simpleType name="t_unix_dirpath">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\s*(~?/[^/]*)+/?\s*"/>
+      <xs:whiteSpace value="collapse"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- RELATIVE directory path -->
+  <xs:simpleType name="t_unix_reldirpath">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\s*[^/](([^/]*)+/?)+\s*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ABSOLUTE file path -->
+  <xs:simpleType name="t_unix_filepath">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\s*(~?/[^/]+)+\s*"/>
+      <xs:whiteSpace value="collapse"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- RELATIVE file path -->
+  <xs:simpleType name="t_unix_relfilepath">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\s*([^/]+)(/[^/]+)*([^/])*\s*"/>
+      <xs:whiteSpace value="collapse"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ABSOLUTE path (file or directory) -->
+  <xs:simpleType name="t_unix_path">
+    <xs:union memberTypes="t_unix_dirpath t_unix_filepath"/>
+  </xs:simpleType>
+
+  <!-- RELATIVE path (file or directory) -->
+  <xs:simpleType name="t_unix_relpath">
+    <xs:union memberTypes="t_unix_reldirpath t_unix_relfilepath"/>
+  </xs:simpleType>
+
+  <!-- ANY valid value for the above types. -->
+  <xs:simpleType name="t_unix_anypath">
+    <xs:union memberTypes="t_unix_path t_unix_relpath"/>
+  </xs:simpleType>
+
+  <!-- RELATIVE or ABSOLUTE file path -->
+  <xs:simpleType name="t_unix_anyfile">
+    <xs:union memberTypes="t_unix_filepath t_unix_relfilepath"/>
+  </xs:simpleType>
+
+    <!-- RELATIVE or ABSOLUTE dir path -->
+  <xs:simpleType name="t_unix_anydir">
+    <xs:union memberTypes="t_unix_dirpath t_unix_reldirpath"/>
+  </xs:simpleType>
+  <!-- END of regex silliness. What an ugly annoyance. -->
+
+  <xs:complexType name="t_unix_nixpass">
+    <xs:choice minOccurs="1" maxOccurs="1">
+      <xs:element name="passwordPlain">
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:string">
+              <xs:attribute name="hashType" use="optional" default="md5" type="t_unix_passwd_hashtypes"/>
+              <xs:attribute name="rounds" use="optional" default="5000" type="xs:positiveInteger"/>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="passwordHash">
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="t_unix_shadowhash">
+              <xs:attribute name="hashType" use="optional" default="md5" type="t_unix_passwd_hashtypes"/>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+    <xs:attribute name="locked" use="optional" default="false" type="xs:boolean"/>
+  </xs:complexType>
+
+  <xs:simpleType name="t_unix_passwd_hashtypes">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="md5"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282 -->
+  <xs:simpleType name="t_unix_portablePosixFilename">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[A-Za-z0-9._-]+"/>
+      <xs:whiteSpace value="collapse"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="t_unix_posixUserGroup">
+    <!-- https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_437
+         https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282
+         https://unix.stackexchange.com/a/435120/284004 -->
+    <xs:restriction base="xs:token">
+      <xs:pattern value="\s*[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}$)\s*"/>
+      <xs:whiteSpace value="collapse"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="t_unix_shadowhash">
+    <!-- http://man7.org/linux/man-pages/man3/crypt.3.html#NOTES -->
+    <xs:restriction base="xs:token">
+      <xs:pattern value="\s*($1)?($[a-zA-Z0-9./]{1,16})$[a-zA-Z0-9./]{22}\s*"/><!-- md5 -->
+      <xs:whiteSpace value="collapse"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="t_unix_user">
+    <xs:sequence>
+      <xs:element name="password" minOccurs="0" maxOccurs="1" type="t_unix_nixpass"/>
+      <xs:element name="xGroup" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:attribute name="name" type="t_unix_posixUserGroup" use="required"/>
+          <xs:attribute name="create" type="xs:boolean" use="optional" default="false"/>
+          <xs:attribute name="gid" type="xs:positiveInteger" use="optional"/>
+        </xs:complexType>
+        <xs:unique name="uniq_unix_grp">
+          <xs:selector xpath="xGroup"/>
+          <xs:field xpath="@name"/>
+        </xs:unique>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="name" type="t_unix_posixUserGroup" use="required"/>
+    <xs:attribute name="home" type="t_unix_filepath" use="optional"/>
+    <xs:attribute name="uid" type="xs:positiveInteger" use="optional"/>
+    <xs:attribute name="group" type="t_unix_posixUserGroup" use="optional"/>
+    <xs:attribute name="gid" type="xs:positiveInteger" use="optional"/>
+    <xs:attribute name="comment" type="t_std_nonempty" use="optional"/>
+    <xs:attribute name="sudo" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="sudoPassword" type="xs:boolean" use="optional" default="true"/>
+    <xs:attribute name="shell" type="t_unix_filepath" use="optional" default="/bin/bash"/>
+    <!-- TODO: change the positiveIntegers to xs:duration? or union? -->
+    <!-- Might be pointless since the smallest increment is 1 day in
+         shadow(5). -->
+    <xs:attribute name="minAge" type="xs:positiveInteger" use="optional"/>
+    <xs:attribute name="maxAge" type="xs:positiveInteger" use="optional"/>
+    <xs:attribute name="warnDays" type="xs:positiveInteger" use="optional"/>
+    <xs:attribute name="inactiveDays" type="xs:positiveInteger" use="optional"/>
+    <xs:attribute name="expireDate" type="t_std_epoch_or_iso" use="optional"/>
+  </xs:complexType>
+
+</xs:schema>

--- a/test/schema/projects/go_libxml2_local.xsd
+++ b/test/schema/projects/go_libxml2_local.xsd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema targetNamespace="http://xmlsoft.org/"
+           xmlns="http://xmlsoft.org/"
+           xmlns:libxml2="http://xmlsoft.org/"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+
+  <xs:include schemaLocation="../lib/types/cksum.xsd"/>
+  <xs:include schemaLocation="../lib/types/std.xsd"/>
+
+  <xs:element name="libxml2">
+    <xs:complexType>
+      <xs:sequence minOccurs="1" maxOccurs="unbounded">
+        <xs:element name="sub">
+          <xs:complexType>
+            <xs:sequence minOccurs="1" maxOccurs="unbounded">
+              <xs:element name="sub2" type="xs:string" minOccurs="0"/>
+              <xs:element name="nestedInclude" type="t_cksum_hash" minOccurs="1" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="attrOpt" use="optional" default="none specified" type="xs:string"/>
+            <xs:attribute name="attrReq" use="required" type="t_std_nonempty"/>
+            <xs:attribute name="attrBoolNoDef" use="optional" type="xs:boolean"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>


### PR DESCRIPTION
As per request in #67, this PR offers test data that fully validates with xmllint but will fail currently:

* `test/go_libxml2_local.xml` validates against `test/schema/go_libxml2_local.xsd` using a relative path to the XML document, with nested relative include directives (all includes should be present in the PR).

```bash
$ xmllint -noout -schema schema/projects/go_libxml2_local.xsd go_libxml2_local.xml 
go_libxml2_local.xml validates
```

* `test/go_libxml2_remote.xml` validates against a remotely sourced schema (**http://schema.xml.r00t2.io/projects/go_libxml2.xsd**) as referenced by its `xsi:schemaLocation` attribute (obviously feel free to host elsewhere and change this if desired; it uses the same exact schema set as included in this PR):

```bash
$ xmllint -noout -schema http://schema.xml.r00t2.io/projects/go_libxml2.xsd go_libxml2_remote.xml 
go_libxml2_remote.xml validates
```