### PR TITLE
fix: Can't deal with Chinese character #56

### DIFF
--- a/html.go
+++ b/html.go
@@ -26,7 +26,7 @@ func ParseHTMLString(content string, options ...parser.HTMLOption) (types.Docume
 	} else {
 		option = parser.DefaultHTMLOptions
 	}
-	docptr, err := clib.HTMLReadDoc(content, "", "", int(option))
+	docptr, err := clib.HTMLReadDoc(content, "", "utf8", int(option))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read document")
 	}


### PR DESCRIPTION
fix: https://github.com/lestrrat-go/libxml2/issues/56
to be compatible with the environment, we muse define encode param.