### PR TITLE
Add stdlib.h clib.go

### DIFF
--- a/clib/clib.go
+++ b/clib/clib.go
@@ -1,5 +1,4 @@
 /*
-
 Package clib holds all of the dirty C interaction for go-libxml2.
 
 Although this package is visible to the outside world, the API in this
@@ -16,12 +15,12 @@ Please DO NOT rely on this API and expect that it will keep backcompat.
 When the need arises, it WILL be changed, and if you are not ready
 for it, your code WILL break in horrible horrible ways. You have been
 warned.
-
 */
 package clib
 
 /*
 #cgo pkg-config: libxml-2.0
+#include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
 #include <stdio.h>


### PR DESCRIPTION
Newer versions of libxml2 doesn't import stdlib.h (this has been doing in SAX.h)

As libxml2 SAX.h and any other header files doesn't import, clib.go crashes with 

`could not determine kind of name for C.free`

This fix makes it work for all version