### PR TITLE
Statically link to libxml2 when `static_build` tag is defined

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           - type: static
             # On Ubuntu, libxml2 is compiled with GCC and is linked to libicu, which introduces a
             # stealth dependency on libstdc++ at link-time
-            goflags: "-ldflags '-extldflags \"-static -lstdc++\"' -tags 'osusergo netgo static_build'"
+            goflags: "-ldflags '-extldflags -lstdc++' -tags 'osusergo netgo static_build'"
     name: "Test [ Go ${{ matrix.go }}, ${{ matrix.link.type }} linking ]"
     env:
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           pacman -Syy --noconfirm
           pacman -Syu --noconfirm
           pacman -S --noconfirm base-devel 
-          pacman -S --noconfirm libxml2=2.12.0
+          pacman -S --noconfirm libxml2=2.12.6
       - name: Set up Go
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
             # stealth dependency on libstdc++ at link-time
             goflags: "-ldflags '-extldflags -lstdc++' -tags 'osusergo netgo static_build'"
     name: "Test [ Go ${{ matrix.go }}, ${{ matrix.link.type }} linking ]"
-    env:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,15 @@ jobs:
     strategy:
       matrix:
         go: [ '1.21' ]
-    name: "Test [ Go ${{ matrix.go }} ]"
+        link:
+          - type: dynamic
+            goflags: ""
+          - type: static
+            # On Ubuntu, libxml2 is compiled with GCC and is linked to libicu, which introduces a
+            # stealth dependency on libstdc++ at link-time
+            goflags: "-ldflags '-extldflags \"-static -lstdc++\"' -tags 'osusergo netgo static_build'"
+    name: "Test [ Go ${{ matrix.go }}, ${{ matrix.link.type }} linking ]"
+    env:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -30,8 +38,12 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
           check-latest: true
-      - name: Test 
-        run: go test ./...
+      - name: Run Go tests
+        run: go test ${{ matrix.link.goflags }} ./...
+      - name: Test linking capability
+        run: |
+          go build -o linktest ${{ matrix.link.goflags }} ./test/link
+          file linktest | grep '${{ matrix.link.type }}ally linked'
   archlinux:
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -278,9 +278,13 @@ pkg-config --list-all
 
 See the first FAQ entry.
 
-### I can't build this library statically
+### I can't statically link this module to libxml2
 
-See prior discussion: https://github.com/lestrrat-go/libxml2/issues/62
+Use the `static_build` tag when building this module, for example:
+
+```sh
+go build -tags static_build
+```
 
 ## See Also
 

--- a/clib/clib.go
+++ b/clib/clib.go
@@ -19,7 +19,6 @@ warned.
 package clib
 
 /*
-#cgo pkg-config: libxml-2.0
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>

--- a/clib/link_dynamic.go
+++ b/clib/link_dynamic.go
@@ -1,0 +1,6 @@
+// +build !static_build
+
+package clib
+
+// #cgo pkg-config: libxml-2.0
+import "C"

--- a/clib/link_static.go
+++ b/clib/link_static.go
@@ -1,0 +1,7 @@
+// +build static_build
+
+package clib
+
+// #cgo pkg-config: --static libxml-2.0
+// #cgo LDFLAGS: -static
+import "C"

--- a/test/link/test.go
+++ b/test/link/test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"github.com/lestrrat-go/libxml2"
+)
+
+func main() {
+	doc, err := libxml2.ParseHTMLString(`<html><body><h1>Hello, World!</h1><p>Lorem Ipsum</p></body></html>`)
+	if err != nil {
+		panic(err)
+	}
+	doc.Free()
+}


### PR DESCRIPTION
There's an unofficial convention in the Go ecosystem that the `static_build` tag indicates a desire to link statically to external libraries detected with pkg-config - examples include:

* [LXC](https://github.com/lxc/go-lxc/blob/ccae595aa49e779f7ecc9250329967aa546acd31/linking_static.go)
* [containers-storage](https://github.com/containers/storage/blob/6c835719e98e403dae4a437e3809e247c9561b29/pkg/devicemapper/devmapper_wrapper_static.go)

Support this convention by invoking pkg-config with the `--static` option if the `static_build` tag is defined, or without if it isn't.