### PR TITLE
Fix "checkptr: pointer arithmetic result points to invalid allocation" panic with race flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           go-version: ${{ matrix.go }}
           check-latest: true
       - name: Run Go tests
-        run: go test ${{ matrix.link.goflags }} ./...
+        run: go test -race ${{ matrix.link.goflags }} ./...
       - name: Test linking capability
         run: |
           go build -o linktest ${{ matrix.link.goflags }} ./test/link

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+.idea


### PR DESCRIPTION
When we run tests with race flag the program crashes with the following panic:

```
fatal error: checkptr: pointer arithmetic result points to invalid allocation

goroutine 1 gp=0xc0000061c0 m=0 mp=0x5cffe0 [running]:
runtime.throw({0x515d10?, 0x46abf9?})
        /usr/lib/go-1.22/src/runtime/panic.go:1023 +0x5c fp=0xc000067c70 sp=0xc000067c40 pc=0x4380dc
runtime.checkptrArithmetic(0x0?, {0x0, 0x0, 0x8?})
        /usr/lib/go-1.22/src/runtime/checkptr.go:69 +0x9c fp=0xc000067ca0 sp=0xc000067c70 pc=0x40b5bc
github.com/lestrrat-go/libxml2/clib.XMLDocumentString.func1(0x253bcd0, 0xc000056028, 0xc00001413c, 0xc000067d08, 0x0)
        /home/bulat/go/pkg/mod/github.com/lestrrat-go/libxml2@v0.0.0-20231124114421-99c71026c2f5/clib/clib.go:1547 +0x4a fp=0xc000067ce0 sp=0xc000067ca0 pc=0x4a93aa
github.com/lestrrat-go/libxml2/clib.XMLDocumentString({0x5321c0, 0xc000014120}, {0x0, 0x0}, 0x0)
        /home/bulat/go/pkg/mod/github.com/lestrrat-go/libxml2@v0.0.0-20231124114421-99c71026c2f5/clib/clib.go:1547 +0x1cf fp=0xc000067ea0 sp=0xc000067ce0 pc=0x4a914f
github.com/lestrrat-go/libxml2/dom.(*Document).String(0xc000014120)
        /home/bulat/go/pkg/mod/github.com/lestrrat-go/libxml2@v0.0.0-20231124114421-99c71026c2f5/dom/node_document.go:260 +0x47 fp=0xc000067ee8 sp=0xc000067ea0 pc=0x4ab647
main.main()
```

Example:
```golang
package main

import (
	"fmt"

	"github.com/lestrrat-go/libxml2"
)

const document = `
<CreateBucketConfiguration> 
	<LocationConstraint>us-east-1</LocationConstraint> 
</CreateBucketConfiguration>
`

func main() {
	document, err := libxml2.Parse([]byte(document))
	if err != nil {
		panic(err)
	}

	fmt.Println(document.String())
}
```

From [docs](https://pkg.go.dev/unsafe#Pointer):
Conversion of a uintptr back to Pointer is not valid in general. It's only allowed in the same expression.

I split the PR into 2 commits:
1) minimal edits so as not to change the ABI
2) replacing uintptr with unsafe.Pointer throughout the project.

I would like to merge both, but the first one is enough for me).