### PR TITLE
Fix crash when printing Namespaces

### DIFF
--- a/dom/node_namespace.go
+++ b/dom/node_namespace.go
@@ -19,3 +19,12 @@ func (n *Namespace) Free() {
 	clib.XMLNamespaceFree(n)
 	n.ptr = 0
 }
+
+// String returns the stringified Namespace
+func (n *Namespace) String() string {
+	prefix := n.Prefix()
+	if prefix != "" {
+		prefix = ":" + prefix
+	}
+	return "xmlns" + prefix + `="` + n.URI() + `"`
+}


### PR DESCRIPTION
You can easily reproduce it with the example:

https://github.com/lestrrat-go/libxml2/blob/b65cd51053703d2b0eb6992c8a815430474578ed/libxml2_example_test.go#L13-L28

```
	defer doc.Free()

	for i := 0; i < 3; i++ {
		root, err := doc.DocumentElement()
		if err != nil {
			panic(err)
		}

		ns, err := root.(types.Element).GetNamespaces()
		if err != nil {
			panic(err)
		}

		log.Println(ns)
	}
```

Without patch:

```
SIGSEGV: segmentation violation
PC=0x7f5b4df295a7 m=0 sigcode=1 addr=0x7f5b006b6b83
signal arrived during cgo execution

goroutine 1 gp=0xc0000061c0 m=0 mp=0x57a320 [syscall]:
runtime.cgocall(0x49f380, 0xc000125430)
        /usr/local/go/src/runtime/cgocall.go:157 +0x4b fp=0xc000125408 sp=0xc0001253d0 pc=0x407eeb
github.com/lestrrat-go/libxml2/clib._Cfunc_xmlNodeDump(0x130e640, 0x7f5b006b6b6b, 0x130eca0, 0x0, 0x0)
        _cgo_gotypes.go:1461 +0x4b fp=0xc000125430 sp=0xc000125408 pc=0x49550b
github.com/lestrrat-go/libxml2/clib.XMLToString.func2(0x130e640, 0x130eca0)
        /path/to/libxml2/clib/clib.go:1083 +0x90 fp=0xc000125470 sp=0xc000125430 pc=0x496f30
github.com/lestrrat-go/libxml2/clib.XMLToString({0x4ed348?, 0xc000014100?}, 0x0, 0x20?)
        /path/to/libxml2/clib/clib.go:1083 +0xa5 fp=0xc0001254d8 sp=0xc000125470 pc=0x496c45
github.com/lestrrat-go/libxml2/dom.(*XMLNode).ToString(...)
        /path/to/libxml2/dom/node.go:226
github.com/lestrrat-go/libxml2/dom.(*XMLNode).String(...)
        /path/to/libxml2/dom/node.go:38
github.com/lestrrat-go/libxml2/dom.(*Namespace).String(0x56fc00?)
        <autogenerated>:1 +0x2d fp=0xc000125508 sp=0xc0001254d8 pc=0x49cccd
fmt.(*pp).handleMethods(0xc00010e340, 0x7a030?)
        /usr/local/go/src/fmt/print.go:673 +0x31f fp=0xc0001256c8 sp=0xc000125508 pc=0x48b5ff
fmt.(*pp).printValue(0xc00010e340, {0x4bfb60?, 0xc00007a030?, 0x48b4f0?}, 0x76, 0x1)
        /usr/local/go/src/fmt/print.go:770 +0xca fp=0xc0001258a8 sp=0xc0001256c8 pc=0x48c16a
fmt.(*pp).printValue(0xc00010e340, {0x4aab00?, 0xc000012018?, 0x7f5b4dc2e108?}, 0x76, 0x0)
        /usr/local/go/src/fmt/print.go:910 +0x1585 fp=0xc000125a88 sp=0xc0001258a8 pc=0x48d625
fmt.(*pp).printArg(0xc00010e340, {0x4aab00, 0xc000012018}, 0x76)
        /usr/local/go/src/fmt/print.go:759 +0x4bc fp=0xc000125b20 sp=0xc000125a88 pc=0x48bf7c
fmt.(*pp).doPrintln(0xc00010e340, {0xc000125e90?, 0x1, 0x6?})
        /usr/local/go/src/fmt/print.go:1221 +0x38 fp=0xc000125b90 sp=0xc000125b20 pc=0x48f8b8
fmt.Appendln({0xc00001c080, 0x14, 0x20}, {0xc000125e90, 0x1, 0x1})
        /usr/local/go/src/fmt/print.go:332 +0x54 fp=0xc000125be8 sp=0xc000125b90 pc=0x489194
main.main.Println.func2({0xc00001c080?, 0xc000012030?, 0x10?})
        /usr/local/go/src/log/log.go:406 +0x25 fp=0xc000125c28 sp=0xc000125be8 pc=0x49e185
log.(*Logger).output(0xc00010c090, 0x0, 0x2, 0xc000125f08)
        /usr/local/go/src/log/log.go:238 +0x35b fp=0xc000125de8 sp=0xc000125c28 pc=0x49187b
log.Println(...)
        /usr/local/go/src/log/log.go:405
```